### PR TITLE
Add `WithOrientations` to improve usage of `@Environment`

### DIFF
--- a/Examples/OrientationKitDemo/ContentView.swift
+++ b/Examples/OrientationKitDemo/ContentView.swift
@@ -3,22 +3,24 @@ import OrientationKit
 
 struct ContentView: View
 {
-    @StateObject
-    private var manager: OrientationManager = .init()
+    /// - Note: Call `.withOrientations()` at root view to extract orientations via `@Environment`.
+    @Environment(\.deviceOrientation)
+    private var deviceOrientation
 
     @Environment(\.interfaceOrientation)
     private var interfaceOrientation
 
+    /// - Note: To grab other `OrientationManager`'s properties e.g. `deviceMotion`, just access via `EnvironmentObject`.
+    @EnvironmentObject
+    private var manager: OrientationManager
+
     var body: some View
     {
-        let deviceOrientation = manager.deviceOrientation
-        let deviceToInterfaceOrientation = deviceOrientation.interfaceOrientation
-
         return VStack(spacing: 20) {
             VStack(spacing: 10) {
                 hStack(
-                    key: "CoreMotion deviceOrientation",
-                    value: "\(deviceOrientation.debugDescription)"
+                    key: "@Environment deviceOrientation",
+                    value: "\(self.deviceOrientation.debugDescription)"
                 )
                 Divider()
                 hStack(
@@ -30,13 +32,8 @@ struct ContentView: View
 
             VStack(spacing: 10) {
                 hStack(
-                    key: "CoreMotion interfaceOrientation",
-                    value: "\(deviceToInterfaceOrientation.debugDescription)"
-                )
-                Divider()
-                hStack(
-                    key: "Env interfaceOrientation",
-                    value: "\(interfaceOrientation().debugDescription)"
+                    key: "@Environment interfaceOrientation",
+                    value: "\(self.interfaceOrientation.debugDescription)"
                 )
                 Divider()
                 hStack(
@@ -49,9 +46,6 @@ struct ContentView: View
             accelerometerText()
         }
         .frame(maxWidth: 500)
-        .onAppear {
-            manager.start(interval: 0.03, queue: .main)
-        }
     }
 
     private func hStack(key: String, value: String) -> some View

--- a/Examples/OrientationKitDemo/SceneDelegate.swift
+++ b/Examples/OrientationKitDemo/SceneDelegate.swift
@@ -16,7 +16,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate
             let window = UIWindow(windowScene: windowScene)
 
             let hostingVC = HostingController(
-                rootView: ContentView()
+                // NOTE:
+                // `withOrientations()` provides
+                // @Environment(\.deviceOrientation) and @Environment(\.interfaceOrientation).
+                rootView: ContentView().withOrientations()
             )
             window.rootViewController = hostingVC
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,47 @@
 # OrientationKit
 iOS device/interface/image/video orientation translation &amp; detection using CoreMotion + SwiftUI + Combine.
 
-See [Examples](Examples) for more information.
+## How to Use
+
+```swift
+@main
+struct DemoApp: App {
+    var body: some Scene {
+        WindowGroup {
+            // Call `.withOrientations()` to start observing 
+            // CoreMotion-based device orientation changes.
+            // This keeps notifying even when device orientation
+            // is locked.
+            ContentView()
+                .withOrientations()
+        }
+    }
+}
+
+struct ContentView: View {
+    @Environment(\.deviceOrientation)
+    private var deviceOrientation
+
+    @Environment(\.interfaceOrientation)
+    private var interfaceOrientation
+
+    /// - Note: To grab other `OrientationManager`'s properties
+    /// e.g. `deviceMotion`, just access via `@EnvironmentObject`.
+    @EnvironmentObject
+    private var manager: OrientationManager
+
+    var body: some View {
+        ...
+    }
+}
+```
+
+## Example
 
 <img src=https://user-images.githubusercontent.com/138476/107111127-c2571b80-6890-11eb-9f02-bc75319abe85.jpeg  width=390>
+
+See [Examples](Examples) for more information.
+
+## License
+
+[MIT](LICENSE)

--- a/Sources/OrientationKit/Environment.swift
+++ b/Sources/OrientationKit/Environment.swift
@@ -1,21 +1,41 @@
 #if canImport(SwiftUI)
 
 import SwiftUI
+import CoreMotion
 
 extension EnvironmentValues
 {
-    /// First window's `UIInterfaceOrientation`.
-    public var interfaceOrientation: () -> UIInterfaceOrientation
+    /// CoreMotion-driven `UIDeviceOrientation` (can also observe changes while orientation lock).
+    public var deviceOrientation: UIDeviceOrientation
     {
-        self[InterfaceOrientationKey.self]
+        get {
+            self[DeviceOrientationKey.self]
+        }
+        set {
+            self[DeviceOrientationKey.self] = newValue
+        }
     }
+
+    /// First window's `UIInterfaceOrientation`.
+    public var interfaceOrientation: UIInterfaceOrientation
+    {
+        get {
+            self[InterfaceOrientationKey.self]
+        }
+        set {
+            self[InterfaceOrientationKey.self] = newValue
+        }
+    }
+}
+
+private struct DeviceOrientationKey: EnvironmentKey
+{
+    public static let defaultValue: UIDeviceOrientation = .unknown
 }
 
 private struct InterfaceOrientationKey: EnvironmentKey
 {
-    public static let defaultValue: () -> UIInterfaceOrientation = {
-        UIApplication.shared.windows.first?.windowScene?.interfaceOrientation ?? .unknown
-    }
+    public static let defaultValue: UIInterfaceOrientation = .unknown
 }
 
 #endif

--- a/Sources/OrientationKit/OrientationManager.swift
+++ b/Sources/OrientationKit/OrientationManager.swift
@@ -15,14 +15,10 @@ public final class OrientationManager: ObservableObject
 
     private var coreMotionManager: CMMotionManager?
 
-    private let strategy: Strategy
-
-    public init(strategy: Strategy = .systemLike)
-    {
-        self.strategy = strategy
-    }
+    public init() {}
 
     public func start(
+        strategy: Strategy = .systemLike,
         interval: TimeInterval,
         queue: OperationQueue = .current ?? .main
     )
@@ -41,7 +37,7 @@ public final class OrientationManager: ObservableObject
 
             self.deviceMotion = data
 
-            let deviceOrientation = self.strategy.calculate(data.gravity)
+            let deviceOrientation = strategy.calculate(data.gravity)
 
             if let deviceOrientation = deviceOrientation {
                 self.deviceOrientation = deviceOrientation

--- a/Sources/OrientationKit/WithOrientations.swift
+++ b/Sources/OrientationKit/WithOrientations.swift
@@ -1,0 +1,89 @@
+#if canImport(SwiftUI)
+
+import SwiftUI
+
+extension View
+{
+    /// Registers `OrientationManager` to provide
+    /// `@Environment(\.deviceOrientation)` and `@Environment(\.interfaceOrientation)`.
+    public func withOrientations(
+        phase: WithOrientations.Phase = .start(strategy: .systemLike, interval: 0.1, queue: .main)
+    ) -> some View
+    {
+        self.modifier(WithOrientations(phase: phase))
+    }
+}
+
+/// Registers `OrientationManager` to provide
+/// `@Environment(\.deviceOrientation)` and `@Environment(\.interfaceOrientation)`.
+public struct WithOrientations: ViewModifier
+{
+    @ObservedObject
+    private var orientationManager: OrientationManager
+
+    @State
+    private var interfaceOrientation: UIInterfaceOrientation = .unknown
+
+    private let phase: Phase
+
+    init(phase: Phase)
+    {
+        self.orientationManager = OrientationManager()
+        self.phase = phase
+    }
+
+    @ViewBuilder
+    public func body(content: Content) -> some View
+    {
+        content
+            .environment(
+                \.deviceOrientation,
+                orientationManager.deviceOrientation
+            )
+            .environment(
+                \.interfaceOrientation,
+                interfaceOrientation
+            )
+            .environmentObject(self.orientationManager)
+            .onReceive(self.orientationManager.$deviceOrientation) { deviceOrientation in
+                let interfaceOrientation = UIApplication.shared.windows.first?.windowScene?.interfaceOrientation ?? .unknown
+
+                if interfaceOrientation != self.interfaceOrientation {
+                    self.interfaceOrientation = interfaceOrientation
+                }
+            }
+            .onAppear {
+                switch self.phase {
+                case let .start(strategy, interval, queue):
+                    self.orientationManager.start(strategy: strategy, interval: interval, queue: queue)
+                case .stop:
+                    self.orientationManager.stop()
+                }
+            }
+    }
+}
+
+extension WithOrientations
+{
+    public enum Phase: Equatable
+    {
+        case start(
+                strategy: OrientationManager.Strategy = .systemLike,
+                interval: TimeInterval = 0.1,
+                queue: OperationQueue = .main
+             )
+
+        case stop
+
+        public static func == (lhs: Self, rhs: Self) -> Bool
+        {
+            switch (lhs, rhs) {
+            case (.start, .start): return true
+            case (.stop, .stop): return true
+            default: return false
+            }
+        }
+    }
+}
+
+#endif

--- a/Tests/OrientationKitTests/OrientationKitTests.swift
+++ b/Tests/OrientationKitTests/OrientationKitTests.swift
@@ -6,7 +6,6 @@ final class OrientationKitTests: XCTestCase {
         // This is an example of a functional test case.
         // Use XCTAssert and related functions to verify your tests produce the correct
         // results.
-        XCTAssertEqual(OrientationKit().text, "Hello, World!")
     }
 
     static var allTests = [


### PR DESCRIPTION
This PR improves the usage of `@Environment` by adding `.withOrientations()`.

```swift
@main
struct DemoApp: App {
    var body: some Scene {
        WindowGroup {
            // Call `.withOrientations()` to start observing 
            // CoreMotion-based device orientation changes.
            // This keeps notifying even when device orientation
            // is locked.
            ContentView()
                .withOrientations()
        }
    }
}

struct ContentView: View {
    @Environment(\.deviceOrientation)
    private var deviceOrientation

    @Environment(\.interfaceOrientation)
    private var interfaceOrientation

    /// - Note: To grab other `OrientationManager`'s properties
    /// e.g. `deviceMotion`, just access via `@EnvironmentObject`.
    @EnvironmentObject
    private var manager: OrientationManager

    var body: some View {
        ...
    }
}
```